### PR TITLE
Masked password in logs

### DIFF
--- a/classes/session.php
+++ b/classes/session.php
@@ -24,7 +24,7 @@ class session {
     }
     else {
       $_SESSION['error'] = 1;
-      logSQL("Invalid login attempt. Bad password from IP: '" . getIP() . "'. Username: '$login' Password: '$pw'.");
+      logSQL("Invalid login attempt. Bad password from IP: '" . getIP() . "'. Username: '$login' Password: '*****'.");
     }
   }
   


### PR DESCRIPTION
my discord linker talkeq will display sql logs to discord, and if an admin is attempting passwords from other systems, this can cause a higher level verbosity than desired.