### PR TITLE
Remove plaintext logging of passwords for login attempts.

### DIFF
--- a/classes/session.php
+++ b/classes/session.php
@@ -17,7 +17,7 @@ class session {
     $result = $mysql->query_assoc($query);
     if ($result == '') {
       $_SESSION['error'] = 1;
-      logSQL("Invalid login attempt. Bad username from IP: '" . getIP() . "'. Username: '$login' Password: '$pw'.");
+      logSQL("Invalid login attempt. Bad username from IP: '" . getIP() . "'. Username: '$login' Password: '*****'.");
       return;
     }
     extract($result);
@@ -125,7 +125,7 @@ if (isset($_GET['login'])) {
   if ($enable_user_login != 1) {
   $login = $_POST['login'];
   $password = $_POST['password'];
-   logSQL("POSSIBLE HACK ATTEMPT. Person was from IP: '" . getIP() . "'. and used Username: '$login' Password: '$password'.");
+   logSQL("POSSIBLE HACK ATTEMPT. Person was from IP: '" . getIP() . "'. and used Username: '$login' Password: '*****'.");
    $_SESSION['error'] = 1;
   }
   else {


### PR DESCRIPTION
Logging plaintext passwords creates more security concerns than it alleviates - there are better ways to mitigate malicious input. This change makes the other two SQL logs in this source file like L29 already is for username checks.