### PR TITLE
Fixing missing hidden field for walkspeed

### DIFF
--- a/templates/npc/npc.tmpl.php
+++ b/templates/npc/npc.tmpl.php
@@ -433,6 +433,7 @@ if ($loottable_id > 0) {
         <input type="hidden" name="sec_melee_type" value="<?=$sec_melee_type?>">
         <input type="hidden" name="ranged_type" value="<?=$ranged_type?>">
         <input type="hidden" name="runspeed" value="<?=$runspeed?>">
+        <input type="hidden" name="walkspeed" value="<?=$walkspeed?>">
         <input type="hidden" name="MR" value="<?=$MR?>">
         <input type="hidden" name="CR" value="<?=$CR?>">
         <input type="hidden" name="DR" value="<?=$DR?>">


### PR DESCRIPTION
Found this when trying to copy an NPC.  Was generating an SQL error indicating that the walkspeed attribute was an empty string.