### PR TITLE
search multiple word npc names

### DIFF
--- a/lib/common.php
+++ b/lib/common.php
@@ -234,6 +234,7 @@ function search_npc_by_id() {
 function search_npcs() {
   global $mysql_content_db;
   $search = $_GET['search'];
+  $search = str_replace(' ', '_', $search);
 
   $query = "SELECT id, name FROM npc_types WHERE name RLIKE \"$search\"";
   $results = $mysql_content_db->query_mult_assoc($query);

--- a/lib/common.php
+++ b/lib/common.php
@@ -235,6 +235,7 @@ function search_npcs() {
   global $mysql_content_db;
   $search = $_GET['search'];
   $search = str_replace(' ', '_', $search);
+  $search = str_replace('`', '-', $search);
 
   $query = "SELECT id, name FROM npc_types WHERE name RLIKE \"$search\"";
   $results = $mysql_content_db->query_mult_assoc($query);


### PR DESCRIPTION
previously doing a search for multi word npcs results in 0 results such as "thall va". This simple fix returns proper results.

Before:
![Screenshot 2025-07-08 094902](https://github.com/user-attachments/assets/1245f2e6-e699-4a53-9ab8-97fc4368a318)

After:
![Screenshot 2025-07-08 094933](https://github.com/user-attachments/assets/d46052b9-e185-4e9d-a91a-ea60563636f2)
